### PR TITLE
Customize topics under a Blog category

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -306,6 +306,37 @@ div#iot, div#adanat {
     display: none;
 }
 
+/*Customize topics under a Blog category [Added By: Saurabh, Date: 15/03/2022] */
+/*
+1. Make topic title and body wider under Blog category (applied only for Desktop) 
+2. Hide the "topic footer buttons" and "SAG info banner" on the topic page for the Blog category
+*/
+@include breakpoint(extra-large,  min-width) {
+    body.category-knowledge-base-blog {
+        .container.posts {
+            grid-template-columns: 94% 6% !important;
+            .topic-area #new-create-topic {
+                margin-right: -4em;
+            }
+            .topic-body {
+                width: 90%;
+            }
+            .topic-area>.loading-container {
+                width: calc( 45px + 917px + (11px * 2));
+            }
+            .topic-status-info, .topic-timer-info {
+                max-width: 100%;
+            }
+            .topic-navigation{
+                margin-left: -3.84em !important;
+            }
+        }
+        #topic-footer-buttons, .topic-above-footer-buttons-outlet, .container #banner {
+            display: none !important;
+        }
+    }
+}
+
 /*Customize topics in a news category*/
 //Make topic title and body wider under News category (apply only for desktop and tablet views) [Added By: Saurabh, Date: 21/09/2021]
 body {


### PR DESCRIPTION
1. Make topic title and body wider (applied only for Desktop)
2. Hide the "topic footer buttons" and "SAG info banner"