### PR TITLE
Customize topics under a Blog category

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1712,3 +1712,11 @@ h1[data-topic-id="235228"] {
 }
 
 // ------ End of CSS Moved From The "my component" ------------
+
+/*Customize topics under a Blog category [Added By: Saurabh, Date: 15/03/2022] */
+//Hide the "topic footer buttons" and "SAG info banner" on the topic page for the Blog category
+body.category-knowledge-base-blog {
+    #topic-footer-buttons, .topic-above-footer-buttons-outlet, .container #banner {
+        display: none !important;
+    }
+}

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -361,6 +361,31 @@ body {
 }
 /*end Customize topics in a news category*/
 
+/*Customize topics under a Blog category [Added By: Saurabh, Date: 15/03/2022] */
+//Make topic title and body wider under Blog category (applied only for Desktop)
+@include breakpoint(extra-large,  min-width) {
+    body.category-knowledge-base-blog {
+        .container.posts {
+            grid-template-columns: 94% 6% !important;
+            .topic-area #new-create-topic {
+                margin-right: -4em;
+            }
+            .topic-body {
+                width: 90%;
+            }
+            .topic-area>.loading-container {
+                width: calc( 45px + 917px + (11px * 2));
+            }
+            .topic-status-info, .topic-timer-info {
+                max-width: 100%;
+            }
+            .topic-navigation{
+                margin-left: -3.84em !important;
+            }
+        }
+    }
+}
+
 //Added the text for the post-control buttons for Desktop view (Like, Share and Bookmark) [Added by: Saurabh; Date: 24-11-2021]
 .container.posts {
 	.post-stream {


### PR DESCRIPTION
1. Make topic title and body wider (applied only for Desktop)
2. Hide the "topic footer buttons" and "SAG info banner"